### PR TITLE
Change in sensates collection since data migration for permissions.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ admin.initializeApp();
 const db = admin.firestore();
 
 export const clusterCreation = functions.firestore
-  .document('sensates/{id}')
+  .document('sensies/{id}')
   .onCreate((snap, context) => {
 
     const newSensateId = context.params.id;
@@ -108,7 +108,7 @@ function getSensatesData(sensates, newSensateId){
     Object.keys(sensates).forEach((sensateKey)=>{
         if(sensateKey !== newSensateId){
             sensatesPromises.push(
-                db.collection('sensates').doc(sensateKey).get().then((sensateData)=>{
+                db.collection('sensies').doc(sensateKey).get().then((sensateData)=>{
                     if(sensateData.exists){
                         return sensateData.data();
                     }else{


### PR DESCRIPTION
There was a needed data migration from the sensates collection to the "sensies" in order to have the firebase uid as key for the documents in the firestore db to ease the permissions for the chat documents.